### PR TITLE
Store metadata on or alongside extracted content

### DIFF
--- a/src/mailingester/extractors.py
+++ b/src/mailingester/extractors.py
@@ -15,6 +15,13 @@ class Extractor:
         return any(address in email.sender for address in self.allowed_addresses)
 
 
+    def extract_meta(self, email: Email) -> dict:
+        return {
+            "sender": email.sender,
+            "subject": email.subject,
+        }
+
+
 class ZambiaExtractor(Extractor):
     FOOTER_START = "-- <br />\nYou received this message"
 
@@ -34,6 +41,7 @@ class ZambiaExtractor(Extractor):
                 ),
                 "utf-8",
             )
+            html.meta = self.extract_meta(email)
 
         return [html]
 
@@ -41,6 +49,7 @@ class ZambiaExtractor(Extractor):
 class MalawiExtractor(Extractor):
 
     def extract(self, email: Email) -> list[Content]:
+        meta = self.extract_meta(email)
         items = []
 
         for item in email.attachments:
@@ -49,6 +58,7 @@ class MalawiExtractor(Extractor):
                 / email.date.strftime("%Y%m%d")
                 / item.filename.with_stem(slugify(item.filename.stem))
             )
+            item.meta = meta
             items.append(item)
 
         return items

--- a/src/mailingester/models.py
+++ b/src/mailingester/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from email.message import EmailMessage
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -9,6 +9,7 @@ class Content:
     content_type: str
     data: bytes
     filename: Path = None
+    meta: dict = field(default_factory=dict)
 
 
 class Email:

--- a/src/mailingester/storage.py
+++ b/src/mailingester/storage.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from google.cloud import storage
@@ -17,6 +18,10 @@ class LocalFileSystem:
         with open(path, "wb") as f:
             f.write(item.data)
 
+        if item.meta:
+            with open(path.with_name(path.name + ".meta.json"), "w") as f:
+                json.dump(item.meta, f, indent=2)
+
 
 class GoogleCloudStorage:
 
@@ -26,4 +31,5 @@ class GoogleCloudStorage:
 
     def save(self, item: Content):
         blob = self.bucket.blob(str(item.filename))
+        blob.metadata = item.meta
         blob.upload_from_string(item.data, item.content_type)

--- a/tests/test_malawi_extractor.py
+++ b/tests/test_malawi_extractor.py
@@ -38,3 +38,7 @@ def test_extract():
         "mw/20240610/evening-weather-bulletin-issued-on-10th-june-2024.pdf"
     )
     assert all(i.data == "Content".encode("utf-8") for i in items)
+    assert all(
+        i.meta == {"sender": "Example <user@example.com>", "subject": "Subject"}
+        for i in items
+    )

--- a/tests/test_zambia_extractor.py
+++ b/tests/test_zambia_extractor.py
@@ -22,3 +22,7 @@ def test_extract():
         "zm/20240729/zambia-evening-weather-forecast-monday-29-06-2024.html"
     )
     assert items[0].data == "<p>Body HTML</p>\n\n".encode("utf-8")
+    assert items[0].meta == {
+        "sender": "Example <user@example.com>",
+        "subject": "ZAMBIA EVENING WEATHER FORECAST: MONDAY (29/06/2024)",
+    }


### PR DESCRIPTION
Storing 'sender' and 'subject', initially. Metadata is stored on Google Storage objects as key-value pairs. For local storage, metadata is stored in a separate JSON file with '.meta.json' extension.

Resolves #10 